### PR TITLE
fix: index data structure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voy-search"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Daw-Chih Liou <dawochih.liou@gmail.com>"]
 edition = "2018"
 description = "a vector similarity search engine in WASM"

--- a/examples/nextjs-transformersjs/pages/index.tsx
+++ b/examples/nextjs-transformersjs/pages/index.tsx
@@ -45,7 +45,7 @@ export default function Home() {
 
     const q = await extract(extractor, query);
 
-    const result = index.search(q, 1);
+    const result = index.search(q, 3);
 
     setResult(result);
   }, []);

--- a/examples/nextjs-transformersjs/pages/index.tsx
+++ b/examples/nextjs-transformersjs/pages/index.tsx
@@ -45,7 +45,7 @@ export default function Home() {
 
     const q = await extract(extractor, query);
 
-    const result = index.search(q, 3);
+    const result = index.search(q, 1);
 
     setResult(result);
   }, []);

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -1,9 +1,11 @@
 use crate::Resource;
 use kiddo::float::{distance::squared_euclidean, kdtree::KdTree};
 use serde::{Deserialize, Serialize};
-use std::convert::TryInto;
+use std::{collections::HashMap, convert::TryInto};
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+use super::hash;
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 
 pub struct Document {
     pub id: String,
@@ -18,18 +20,18 @@ pub enum Query {
     Embeddings(Vec<f32>),
 }
 
-pub type Tree = KdTree<f32, usize, 768, 32, u16>;
+pub type Tree = KdTree<f32, u64, 768, 32, u16>;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Index {
     // "IDX" is set to u16 to optimize CPU cache.
     // Read more: https://github.com/sdd/kiddo/blob/7a0bb6ecce39963b27ffdca913c6be7a265e3523/src/types.rs#L35
     pub tree: Tree,
-    pub data: Vec<Document>,
+    pub data: HashMap<u64, Document>,
 }
 
 pub fn index(resource: Resource) -> anyhow::Result<Index> {
-    let data: Vec<Document> = resource
+    let data_vec: Vec<(u64, Document)> = resource
         .embeddings
         .iter()
         .map(|resource| Document {
@@ -37,21 +39,24 @@ pub fn index(resource: Resource) -> anyhow::Result<Index> {
             title: resource.title.to_owned(),
             url: resource.url.to_owned(),
         })
+        .map(|document| (hash(&document), document))
         .collect();
+
+    let data: HashMap<u64, Document> = data_vec.clone().into_iter().collect();
 
     let mut tree: Tree = KdTree::new();
 
     resource
         .embeddings
         .iter()
-        .enumerate()
-        .for_each(|(index, resource)| {
+        .zip(&data_vec)
+        .for_each(|(resource, data)| {
             let mut embeddings = resource.embeddings.clone();
             embeddings.resize(768, 0.0);
 
             let query: &[f32; 768] = &embeddings.try_into().unwrap();
             // "item" holds the position of the document in "data"
-            tree.add(query, index)
+            tree.add(query, data.0.clone());
         });
 
     Ok(Index { tree, data })
@@ -69,8 +74,10 @@ pub fn search<'a>(index: &'a Index, query: &'a Query, k: usize) -> anyhow::Resul
     let mut result: Vec<Document> = vec![];
 
     for neighbor in &neighbors {
-        let doc = index.data[neighbor.item].to_owned();
-        result.push(doc);
+        let doc = index.data.get(&neighbor.item);
+        if let Some(document) = doc {
+            result.push(document.to_owned());
+        }
     }
 
     Ok(result)
@@ -87,8 +94,9 @@ pub fn add<'a>(index: &'a mut Index, resource: &'a Resource) {
             title: item.title.to_owned(),
             url: item.url.to_owned(),
         };
-        index.data.push(doc);
-        index.tree.add(query, index.data.len() - 1);
+        let id = hash(&doc);
+        index.data.insert(id, doc);
+        index.tree.add(query, id);
     }
 }
 
@@ -98,12 +106,14 @@ pub fn remove<'a>(index: &'a mut Index, resource: &'a Resource) {
         embeddings.resize(768, 0.0);
 
         let query: &[f32; 768] = &embeddings.try_into().unwrap();
-        let doc_index = index.data.iter().position(|x| x.id == item.id);
+        let id = hash(&Document {
+            id: item.id.to_owned(),
+            title: item.title.to_owned(),
+            url: item.url.to_owned(),
+        });
 
-        if let Some(i) = doc_index {
-            index.tree.remove(query, i);
-            index.data.remove(i);
-        }
+        index.tree.remove(query, id);
+        index.data.remove(&id);
     }
 }
 
@@ -111,5 +121,9 @@ pub fn clear<'a>(index: &'a mut Index) {
     // simply assign a new tree and data because traversing the nodes to perform removal is the only alternative.
     // Kiddo provides only basic removal. See more: https://github.com/sdd/kiddo/issues/76
     index.tree = KdTree::new();
-    index.data = Vec::new();
+    index.data = HashMap::new();
+}
+
+pub fn size<'a>(index: &'a Index) -> usize {
+    index.data.len()
 }

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -49,14 +49,14 @@ pub fn index(resource: Resource) -> anyhow::Result<Index> {
     resource
         .embeddings
         .iter()
-        .zip(&data_vec)
+        .zip(data_vec.iter())
         .for_each(|(resource, data)| {
             let mut embeddings = resource.embeddings.clone();
             embeddings.resize(768, 0.0);
 
             let query: &[f32; 768] = &embeddings.try_into().unwrap();
             // "item" holds the position of the document in "data"
-            tree.add(query, data.0.clone());
+            tree.add(query, data.0);
         });
 
     Ok(Index { tree, data })

--- a/src/engine/hash.rs
+++ b/src/engine/hash.rs
@@ -1,0 +1,9 @@
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+pub fn hash<T: Hash>(target: &T) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    target.hash(&mut hasher);
+
+    hasher.finish()
+}

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,6 +1,8 @@
 mod engine;
+mod hash;
 
 #[cfg(test)]
 mod tests;
 
-pub use engine::{add, clear, index, remove, search, Index, Query};
+pub use engine::{add, clear, index, remove, search, size, Index, Query};
+pub use hash::hash;

--- a/src/engine/tests/mod.rs
+++ b/src/engine/tests/mod.rs
@@ -80,3 +80,11 @@ fn it_clears_all_embeddings_from_index(resource_fixture: Resource) {
     assert_eq!(index.tree.size(), 0);
     assert_eq!(index.data.len(), 0);
 }
+
+#[rstest]
+fn it_returns_the_size_of_index(resource_fixture: Resource) {
+    let index = engine::index(resource_fixture).unwrap();
+    assert_eq!(index.tree.size(), 6);
+    assert_eq!(index.data.len(), 6);
+    assert_eq!(engine::size(&index), 6);
+}

--- a/src/wasm/fns.rs
+++ b/src/wasm/fns.rs
@@ -71,5 +71,5 @@ pub fn size(index: SerializedIndex) -> usize {
 
     let index: engine::Index = serde_json::from_str(&index).unwrap();
 
-    index.data.len()
+    engine::size(&index)
 }

--- a/src/wasm/voy.rs
+++ b/src/wasm/voy.rs
@@ -64,6 +64,6 @@ impl Voy {
     }
 
     pub fn size(&self) -> usize {
-        self.index.data.len()
+        engine::size(&self.index)
     }
 }


### PR DESCRIPTION
Use hash map instead of vector to store the document info. It fixes the bug where removing resources changes the data index.