### PR TITLE
GH-50: Reduce bucket size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voy-search"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["Daw-Chih Liou <dawochih.liou@gmail.com>"]
 edition = "2018"
 description = "a vector similarity search engine in WASM"

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -20,6 +20,9 @@ pub enum Query {
     Embeddings(Vec<f32>),
 }
 
+// Wasm has a 4GB memory limit. Should make sure the bucket size and capacity
+// doesn't exceed it and cause stack overflow.
+// More detail: https://v8.dev/blog/4gb-wasm-memory
 const BUCKET_SIZE: usize = 32;
 
 pub type Tree = KdTree<f32, u64, 768, BUCKET_SIZE, u16>;

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -20,7 +20,7 @@ pub enum Query {
     Embeddings(Vec<f32>),
 }
 
-const BUCKET_SIZE: usize = 256;
+const BUCKET_SIZE: usize = 32;
 
 pub type Tree = KdTree<f32, u64, 768, BUCKET_SIZE, u16>;
 


### PR DESCRIPTION
Browsers limit the memory size to 4GB for Wasm. This PR addresses the issue and reduce the bucket size to 32 to make sure the index deserialization is safe from stack overflow.